### PR TITLE
Fix #85 and update cargo manifests

### DIFF
--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "x11-dl"
-version = "2.17.5"
+version = "2.18.0"
 authors = ["Daggerbot <daggerbot@gmail.com>"]
 description = "X11 library bindings for Rust"
 license = "CC0-1.0"
-repository = "https://github.com/Daggerbot/x11-rs.git"
+repository = "https://gitlab.com/daggerbot/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11-dl"
 workspace = ".."

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "x11-dl"
-version = "2.18.0"
-authors = ["Daggerbot <daggerbot@gmail.com>"]
+version = "2.18.1"
+authors = [
+    "daggerbot <daggerbot@gmail.com>",
+    "Erle Pereira <erle@erlepereira.com>",
+]
 description = "X11 library bindings for Rust"
 license = "CC0-1.0"
-repository = "https://gitlab.com/daggerbot/x11-rs.git"
+repository = "https://github.com/erlepereira/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11-dl"
 workspace = ".."

--- a/x11-dl/build.rs
+++ b/x11-dl/build.rs
@@ -10,25 +10,28 @@ use std::io::Write;
 use std::path::Path;
 
 fn main() {
-    let libraries = ["xext",
-                     "gl",
-                     "xcursor",
-                     "xxf86vm",
-                     "xft",
-                     "xinerama",
-                     "xi",
-                     "x11",
-                     "xlib_xcb",
-                     "xmu",
-                     "xrandr",
-                     "xtst",
-                     "xrender",
-                     "xscrnsaver",
-                     "xt"];
+    let libraries = [
+        // lib           pkgconfig name
+        ("xext",        "xext"),
+        ("gl",          "gl"),
+        ("xcursor",     "xcursor"),
+        ("xxf86vm",     "xxf86vm"),
+        ("xft",         "xft"),
+        ("xinerama",    "xinerama"),
+        ("xi",          "xi"),
+        ("x11",         "x11"),
+        ("xlib_xcb",    "x11-xcb"),
+        ("xmu",         "xmu"),
+        ("xrandr",      "xrandr"),
+        ("xtst",        "xtst"),
+        ("xrender",     "xrender"),
+        ("xscrnsaver",  "xscrnsaver"),
+        ("xt",          "xt"),
+    ];
 
     let mut config = String::new();
-    for lib in libraries.iter() {
-        let libdir = match pkg_config::get_variable(lib, "libdir") {
+    for (lib, pcname) in libraries.iter() {
+        let libdir = match pkg_config::get_variable(pcname, "libdir") {
             Ok(libdir) => format!("Some(\"{}\")", libdir),
             Err(_) => "None".to_string(),
         };

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "x11"
-version = "2.17.5"
+version = "2.18.0"
 authors = ["Daggerbot <daggerbot@gmail.com>"]
 description = "X11 library bindings for Rust"
 license = "CC0-1.0"
-repository = "https://github.com/Daggerbot/x11-rs.git"
+repository = "https://gitlab.com/daggerbot/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11"
 workspace = ".."

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "x11"
-version = "2.18.0"
-authors = ["Daggerbot <daggerbot@gmail.com>"]
+version = "2.18.1"
+authors = [
+    "daggerbot <daggerbot@gmail.com>",
+    "Erle Pereira <erle@erlepereira.com>",
+]
 description = "X11 library bindings for Rust"
 license = "CC0-1.0"
-repository = "https://gitlab.com/daggerbot/x11-rs.git"
+repository = "https://github.com/erlepereira/x11-rs.git"
 build = "build.rs"
 documentation = "https://docs.rs/x11"
 workspace = ".."


### PR DESCRIPTION
This contains @goertzenator's pull request from gitlab and updates both cargo manifests. They now point to the correct repository (@erlepereira's repo here, rather than mine on gitlab), include erlepereira in the list of authors, and version is bumped to reflect the changes. We can publish this version and yank 2.18.0 to prevent my github/gitlab mixup from occurring again.