### PR TITLE
bool -> Bool

### DIFF
--- a/src/xf86vmode.rs
+++ b/src/xf86vmode.rs
@@ -137,7 +137,7 @@ pub struct XF86VidModeNotifyEvent {
   pub root: Window,
   pub state: c_int,
   pub kind: c_int,
-  pub forced: bool,
+  pub forced: Bool,
   pub time: Time,
 }
 


### PR DESCRIPTION
This could have been causing UB when using `mem::uninitialized()` on an `XEvent`.
I'm not sure how unions handle such things...

Regardless this value was clearly meant to be a `Bool`. https://www.x.org/releases/current/doc/man/man3/XF86VM.3.xhtml