### PR TITLE
Uncomment None constant

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -3224,7 +3224,7 @@ pub const LSBFirst: c_int = 0;
 pub const MSBFirst: c_int = 1;
 
 // Reserved resource and constant definitions
-//pub const None: c_int = 0;
+pub const None: c_int = 0;
 pub const ParentRelative: c_int = 1;
 pub const CopyFromParent: c_int = 0;
 pub const PointerWindow: c_int = 0;


### PR DESCRIPTION
I'm assuming this was commented out to avoid shadowing
`std::option::Option::None`. However, aside from the fact that this
essentially excludes a symbol from the library bindings that should be
included, this is really not necessary. There are other ways for client
code to avoid this issue, such as avoiding importing `x11::xlib::*` or
re-exporting either `std::option::Option::None` or `x11::xlib::None`
under a different name.