### PR TITLE
Add Xcomposite bindings

### DIFF
--- a/src/xcomposite.rs
+++ b/src/xcomposite.rs
@@ -1,0 +1,43 @@
+// x11-rs: Rust bindings for X11 libraries
+// The X11 libraries are available under the MIT license.
+// These bindings are public domain.
+
+use std::os::raw::{
+  c_int,
+};
+
+use ::xlib::{
+  Bool,
+  XID,
+  Status,
+  Window,
+  Display,
+};
+
+//
+// functions
+//
+
+x11_link! { Xcomposite, xcomposite, ["libXcomposite.so.1", "libXcomposite.so"], 11,
+  pub fn XCompositeQueryExtension(_3: *mut Display, _2: *mut c_int, _1: *mut c_int) -> Bool,
+  pub fn XCompositeQueryVersion(_3: *mut Display, _2: *mut c_int, _1: *mut c_int) -> Status,
+  pub fn XCompositeVersion() -> c_int,
+  pub fn XCompositeRedirectWindow(_3: *mut Display, _2: Window, _1: c_int) -> (),
+  pub fn XCompositeRedirectSubwindows(_3: *mut Display, _2: Window, _1: c_int) -> (),
+  pub fn XCompisiteUnredirectWindow(_3: *mut Display, _2: Window, _1: c_int) -> (),
+  pub fn XCompisiteUnredirectSubwindows(_3: *mut Display, _2: Window, _1: c_int) -> (),
+  pub fn XCompisiteCreateRegionFromBorderClip(_2: *mut Display, _1: Window) -> XserverRegion,
+  pub fn XCompositeNameWindowPixmap(_2: *mut Display, _1: Window) -> Pixmap,
+  pub fn XCompositeGetOverlayWindow(_2: *mut Display, _1: Window) -> Window,
+  pub fn XCompisiteReleaseOverlayWindow(_2: *mut Display, _1: Window) -> (),
+variadic:
+globals:
+}
+
+
+//
+// types
+//
+
+pub type XserverRegion = XID;
+pub type Pixmap = XID;

--- a/x11-dl/Cargo.toml
+++ b/x11-dl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x11-dl"
-version = "2.18.5"
+version = "2.18.6"
 authors = [
     "daggerbot <daggerbot@gmail.com>",
     "Erle Pereira <erle@erlepereira.com>",

--- a/x11-dl/build.rs
+++ b/x11-dl/build.rs
@@ -14,6 +14,7 @@ fn main() {
         // lib           pkgconfig name
         ("xext",        "xext"),
         ("gl",          "gl"),
+        ("xcomposite",  "xcomposite"),
         ("xcursor",     "xcursor"),
         ("xxf86vm",     "xxf86vm"),
         ("xft",         "xft"),

--- a/x11-dl/src/lib.rs
+++ b/x11-dl/src/lib.rs
@@ -24,6 +24,7 @@ pub mod xlib;
 pub mod dpms;
 pub mod glx;
 pub mod keysym;
+pub mod xcomposite;
 pub mod xcursor;
 pub mod xf86vmode;
 pub mod xfixes;

--- a/x11-dl/src/xcomposite.rs
+++ b/x11-dl/src/xcomposite.rs
@@ -1,0 +1,1 @@
+../../src/xcomposite.rs

--- a/x11/Cargo.toml
+++ b/x11/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x11"
-version = "2.18.2"
+version = "2.18.3"
 authors = [
     "daggerbot <daggerbot@gmail.com>",
     "Erle Pereira <erle@erlepereira.com>",
@@ -15,6 +15,7 @@ workspace = ".."
 [features]
 dpms = []
 glx = []
+xcomposite = []
 xcursor = []
 xf86vmode = []
 xft = []

--- a/x11/build.rs
+++ b/x11/build.rs
@@ -13,6 +13,7 @@ fn main () {
     ("gl", "1", "glx"),
     ("x11", "1.4.99.1", "xlib"),
     ("x11-xcb", "1.6", "xlib_xcb"),
+    ("xcomposite", "0.4.5", "xcomposite"),
     ("xcursor", "1.1", "xcursor"),
     ("xext", "1.3", "dpms"),
     ("xft", "2.1", "xft"),

--- a/x11/src/lib.rs
+++ b/x11/src/lib.rs
@@ -19,6 +19,7 @@ pub mod xlib;
 pub mod dpms;
 pub mod glx;
 pub mod keysym;
+pub mod xcomposite;
 pub mod xcursor;
 pub mod xf86vmode;
 pub mod xfixes;

--- a/x11/src/xcomposite.rs
+++ b/x11/src/xcomposite.rs
@@ -1,0 +1,1 @@
+../../src/xcomposite.rs


### PR DESCRIPTION
Didn't test this too much, but it looks like the `x11` crate bindings work on my end. Some test code:

```rust
use std::ptr::{null};
use std::os::raw::c_int;
use x11::xlib::*;
use x11::xcomposite::*;

fn main() {
    unsafe {
        let mut event_base_return: c_int = 0;
        let mut error_base_return: c_int = 0;

        let display = XOpenDisplay(null());
        if display.is_null() {
            panic!("Failed to open default X display.");
        }

        XCompositeQueryExtension(display, &mut event_base_return, &mut error_base_return);
        let xcomposite_version = XCompositeVersion();

        println!("{} {}", event_base_return, error_base_return);
        println!("{}", xcomposite_version);
    }
}
```